### PR TITLE
Remove unneeded method

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -76,12 +76,6 @@ module OmniAuth
       def profile_endpoint
         '/v2/userinfo'
       end
-
-      def token_params
-        super.tap do |params|
-          params.client_secret = options.client_secret
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
As per #2, removing this method allows the gem to work. I had seen also that someone suggested upgrading oauth2 to > 2. But since our application is also using the omniauth google gem, it's locked to ~> 1.4.