### PR TITLE
Change request method strategy when validating access token

### DIFF
--- a/lib/omniauth/strategies/linkedin.rb
+++ b/lib/omniauth/strategies/linkedin.rb
@@ -8,7 +8,8 @@ module OmniAuth
       option :client_options, {
         :site => 'https://api.linkedin.com',
         :authorize_url => 'https://www.linkedin.com/oauth/v2/authorization?response_type=code',
-        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken'
+        :token_url => 'https://www.linkedin.com/oauth/v2/accessToken',
+        :token_method => :post_with_query_string
       }
 
       option :scope, 'openid profile email'

--- a/spec/omniauth/strategies/linkedin_spec.rb
+++ b/spec/omniauth/strategies/linkedin_spec.rb
@@ -20,6 +20,10 @@ describe OmniAuth::Strategies::LinkedIn do
     it 'has correct `token_url`' do
       expect(subject.client.options[:token_url]).to eq('https://www.linkedin.com/oauth/v2/accessToken')
     end
+
+    it 'has a correct `token_method`' do
+      expect(subject.client.options[:token_method]).to eq(:post_with_query_string)
+    end
   end
 
   describe '#callback_path' do


### PR DESCRIPTION
_(Resolves #6)_

There is a [known issue](https://stackoverflow.com/a/25601874) (since 10 years ago) with the LinkedIn API when getting an access token sending the params in the body of a `POST` request, that returns random `REVOKED_ACCESS_TOKEN` responses.

There is also an [open issue](https://github.com/decioferreira/omniauth-linkedin-oauth2/issues/17) in the `omniauth-linkedin-oauth2` repository about the same error that has a lot more details.

The workaround is to provide the same params as query params for the `POST` request instead of body params. Thankfully, the `oauth2` gem already has a setting for this, so the fix is quite easy.

I tested this on a production site and the random `REVOKED_ACCESS_TOKEN` errors seems to be fixed now.